### PR TITLE
Update the build for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: java
+jdk: oraclejdk8
+branches:
+  only:
+  - master
+  - "/.*-[0-9]+\\..*/"
+install: true
+script: ".travis/build.sh"
+cache:
+  directories:
+  - "~/.m2/repository"

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+curl -fsLO https://raw.githubusercontent.com/scijava/scijava-scripts/master/travis-build.sh
+sh travis-build.sh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![](https://travis-ci.com/ssgpers/java-utils-embl.svg?branch=master)](https://travis-ci.com/ssgpers/java-utils-embl)
+
 Shared utilities
 
 Support function for developing ImageJ/Fiji/ImageJ2 plugins and pipelines. 

--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
 
 	<mailingLists>
 		<mailingList>
-			<name>ImageJ Forum</name>
-			<archive>http://forum.imagej.net/</archive>
+			<name>Image.sc Forum</name>
+			<archive>https://forum.image.sc/</archive>
 		</mailingList>
 	</mailingLists>
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,10 @@
 	</issueManagement>
 
 	<scm>
+		<connection>scm:git:git://github.com/ssgpers/java-utils-embl</connection>
+		<developerConnection>scm:git:git@github.com:ssgpers/java-utils-embl</developerConnection>
 		<tag>HEAD</tag>
+		<url>https://github.com/ssgpers/java-utils-embl</url>
 	</scm>
 	<ciManagement>
 		<system>None</system>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 	</ciManagement>
 
 	<properties>
-		<package-name>embl.cba.utils</package-name>
+		<package-name>de.embl.cba.utils</package-name>
 		<main-class>com.mycompany.imagej.Process_Pixels</main-class>
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>EMBL</license.copyrightOwners>

--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-		http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -13,9 +10,12 @@
 	</parent>
 
 	<groupId>de.embl.cba</groupId>
+	<artifactId>java-utils-embl</artifactId>
 	<version>0.0.5-SNAPSHOT</version>
 
 	<name>java-utils-embl</name>
+	<description>Tool functions of broader use.</description>
+	<url>https://www.embl.de/</url>
 	<inceptionYear>2018</inceptionYear>
 	<organization>
 		<name>EMBL</name>
@@ -27,7 +27,7 @@
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
-	<url>https://www.embl.de/</url>
+
 	<developers>
 		<developer>
 			<id>halavaty</id>
@@ -63,17 +63,16 @@
 		</mailingList>
 	</mailingLists>
 
-	<issueManagement>
-		<system>GitHub Issues</system>
-		<url>https://github.com/ssgpers/java-utils-embl/issues</url>
-	</issueManagement>
-
 	<scm>
 		<connection>scm:git:git://github.com/ssgpers/java-utils-embl</connection>
 		<developerConnection>scm:git:git@github.com:ssgpers/java-utils-embl</developerConnection>
 		<tag>HEAD</tag>
 		<url>https://github.com/ssgpers/java-utils-embl</url>
 	</scm>
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/ssgpers/java-utils-embl/issues</url>
+	</issueManagement>
 	<ciManagement>
 		<system>Travis CI</system>
 		<url>https://travis-ci.com/ssgpers/java-utils-embl</url>
@@ -86,11 +85,6 @@
 		<license.projectName>Tool functions for the developing Fiji-dependent and other Java projects.</license.projectName>
 	</properties>
 
-
-	<artifactId>java-utils-embl</artifactId>
-	<description>Tool functions of broader use.</description>
-
-
 	<repositories>
 
 		<repository>
@@ -99,7 +93,6 @@
 		</repository>
 
 	</repositories>
-
 
 	<dependencies>
 
@@ -114,7 +107,4 @@
 		</dependency>
 
 	</dependencies>
-
-
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,6 @@
 		<license.copyrightOwners>EMBL</license.copyrightOwners>
 		<license.projectName>Tool functions for the developing Fiji-dependent and other Java projects.</license.projectName>
 
-		<imagej.app.directory>/Applications/Fiji.app/</imagej.app.directory>
 		<enforcer.skip>true</enforcer.skip>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,6 @@
 		<developer>
 			<id>halavaty</id>
 			<name>Aliaksandr Halavatyi</name>
-			<url>None</url>
 			<roles>
 				<role>lead</role>
 				<role>developer</role>
@@ -46,7 +45,6 @@
 	<contributors>
 		<contributor>
 			<name>Christian Tischer</name>
-			<url>None</url>
 			<roles>
 				<role>founder</role>
 				<role>developer</role>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	</parent>
 
 	<groupId>de.embl.cba</groupId>
-	<version>0.0.4</version>
+	<version>0.0.5-SNAPSHOT</version>
 
 	<name>java-utils-embl</name>
 	<inceptionYear>2018</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,8 @@
 		<url>https://github.com/ssgpers/java-utils-embl</url>
 	</scm>
 	<ciManagement>
-		<system>None</system>
+		<system>Travis CI</system>
+		<url>https://travis-ci.com/ssgpers/java-utils-embl</url>
 	</ciManagement>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,9 @@
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>EMBL</license.copyrightOwners>
 		<license.projectName>Tool functions for the developing Fiji-dependent and other Java projects.</license.projectName>
+
+		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
+		<releaseProfiles>deploy-to-imagej</releaseProfiles>
 	</properties>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@
 
 	<properties>
 		<package-name>de.embl.cba.utils</package-name>
-		<main-class>com.mycompany.imagej.Process_Pixels</main-class>
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>EMBL</license.copyrightOwners>
 		<license.projectName>Tool functions for the developing Fiji-dependent and other Java projects.</license.projectName>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
-	<url>http://embl.de/</url>
+	<url>https://www.embl.de/</url>
 	<developers>
 		<developer>
 			<id>halavaty</id>
@@ -95,7 +95,7 @@
 
 		<repository>
 			<id>imagej.public</id>
-			<url>http://maven.imagej.net/content/groups/public</url>
+			<url>https://maven.imagej.net/content/groups/public</url>
 		</repository>
 
 	</repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,6 @@
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>EMBL</license.copyrightOwners>
 		<license.projectName>Tool functions for the developing Fiji-dependent and other Java projects.</license.projectName>
-
-		<enforcer.skip>true</enforcer.skip>
 	</properties>
 
 


### PR DESCRIPTION
This enables Travis CI builds for the project. For details, see the [Travis page](https://imagej.net/Travis).

It will not enable deployment of snapshots or releases to `maven.imagej.net` yet, because we have to add the encrypted credentials first. And we cannot do that until an admin for this project visits https://travis-ci.com/ and [enables Travis for the repository](https://docs.travis-ci.com/user/tutorial/).

Once Travis is enabled, I can file another PR adding the encrypted credentials, such that Travis CI automatically deploys the built artifacts to `maven.imagej.net` from the master branch, and from release tags.